### PR TITLE
Fix deserialize bytes in Python3

### DIFF
--- a/src/genpy/generator.py
+++ b/src/genpy/generator.py
@@ -437,10 +437,13 @@ def string_serializer_generator(package, type_, name, serialize):
             yield "%s = str[start:end]" % var
         else:
             yield "end += length"
-            yield "if python3:"
-            yield INDENT+"%s = str[start:end].decode('utf-8')" % (var) #If messages are python3-decode back to unicode
-            yield "else:"
-            yield INDENT+"%s = str[start:end]" % (var)
+            if base_type in ['uint8', 'char']:
+                yield "%s = str[start:end]" % (var)
+            else:
+                yield "if python3:"
+                yield INDENT+"%s = str[start:end].decode('utf-8')" % (var) #If messages are python3-decode back to unicode
+                yield "else:"
+                yield INDENT+"%s = str[start:end]" % (var)
 
 
 def array_serializer_generator(msg_context, package, type_, name, serialize, is_numpy):


### PR DESCRIPTION
See #9 and https://github.com/laas/morse/issues/218

`data` in Image and PointCloud2 should be kept as bytes, not decoded as utf-8.

Tested with:

```
./scripts/genmsg_py.py -p sensor_msgs -Istd_msgs:`rospack find std_msgs`/msg -Isensor_msgs:`rospack find sensor_msgs`/msg -o gen `rospack find sensor_msgs`/msg/Image.msg

diff -ur1 /opt/ros/fuerte/lib/python2.7/dist-packages/sensor_msgs/msg/_Image.py gen/_Image.py
```
