### PR TITLE
if data is not ascii, we'll convert them to unicode

### DIFF
--- a/src/genpy/generator.py
+++ b/src/genpy/generator.py
@@ -446,7 +446,11 @@ def string_serializer_generator(package, type_, name, serialize):
                 yield "if python3:"
                 yield INDENT+"%s = str[start:end].decode('utf-8')" % (var) #If messages are python3-decode back to unicode
                 yield "else:"
-                yield INDENT+"%s = str[start:end]" % (var)
+                yield INDENT+"try:"
+                yield INDENT+INDENT+"str[start:end].decode('ascii')"
+                yield INDENT+INDENT+"%s = str[start:end]" % (var)
+                yield INDENT+"except UnicodeDecodeError:"
+                yield INDENT+INDENT+"%s = str[start:end].decode('utf-8')" % (var)
 
 
 def array_serializer_generator(msg_context, package, type_, name, serialize, is_numpy):


### PR DESCRIPTION
Current implementation transfers unicode string to str string during serialization and deserialization
https://github.com/ros/ros_comm/pull/530/files#diff-6907356c07d5398105854fc29f684d12R228
https://github.com/ros/ros_comm/pull/530/files#diff-6907356c07d5398105854fc29f684d12R232

```
a = s.call(u'ほげ')
a.str == 'ほげ' # Not u'ほげ'
```

I think this is current specification, but just in case this is bug, here is the fix for that.
If we accept this patch, we have to fix test code https://github.com/ros/ros_comm/pull/530
