### PR TITLE
Use numpy.array's "offset" param instead of slicing

### DIFF
--- a/src/genpy/generate_numpy.py
+++ b/src/genpy/generate_numpy.py
@@ -56,11 +56,11 @@ NUMPY_DTYPE = {
     'byte' : 'numpy.int8',
     }
 # TODO: this doesn't explicitly specify little-endian byte order on the numpy data instance
-def unpack_numpy(var, count, dtype, buff):
+def unpack_numpy(var, offset, count, dtype, buff):
     """
     create numpy deserialization code
     """
-    return var + " = numpy.frombuffer(%s, dtype=%s, count=%s)"%(buff, dtype, count)
+    return var + " = numpy.frombuffer(%s, dtype=%s, count=%s, offset=%s)"%(buff, dtype, count, offset)
 
 def pack_numpy(var):
     """

--- a/src/genpy/generator.py
+++ b/src/genpy/generator.py
@@ -491,7 +491,7 @@ def array_serializer_generator(msg_context, package, type_, name, serialize, is_
                 yield "end += struct.calcsize(pattern)"
                 if is_numpy:
                     dtype = NUMPY_DTYPE[base_type]
-                    yield unpack_numpy(var, 'length', dtype, 'str[start:end]')
+                    yield unpack_numpy(var, 'start', 'length', dtype, 'str')
                 else:
                     yield unpack2(var, 'pattern', 'str[start:end]')
         else:
@@ -506,7 +506,7 @@ def array_serializer_generator(msg_context, package, type_, name, serialize, is_
                 yield "end += %s"%struct.calcsize('<%s'%pattern)
                 if is_numpy:
                     dtype = NUMPY_DTYPE[base_type]
-                    yield unpack_numpy(var, length, dtype, 'str[start:end]')
+                    yield unpack_numpy(var, 'start', length, dtype, 'str')
                 else:
                     yield unpack(var, pattern, 'str[start:end]')
         if not serialize and base_type == 'bool':

--- a/test/files/array/int16_fixed_deser_np.txt
+++ b/test/files/array/int16_fixed_deser_np.txt
@@ -1,3 +1,3 @@
 start = end
 end += 20
-data = numpy.frombuffer(str[start:end], dtype=numpy.int16, count=10)
+data = numpy.frombuffer(str, dtype=numpy.int16, count=10, offset=start)

--- a/test/files/array/int16_varlen_deser_np.txt
+++ b/test/files/array/int16_varlen_deser_np.txt
@@ -4,4 +4,4 @@ end += 4
 pattern = '<%sh'%length
 start = end
 end += struct.calcsize(pattern)
-data = numpy.frombuffer(str[start:end], dtype=numpy.int16, count=length)
+data = numpy.frombuffer(str, dtype=numpy.int16, count=length, offset=start)


### PR DESCRIPTION
Passing an offset into numpy.array instead of slicing should prevent an
additional copy of the data being created by the slice operation. This is
important for really big message types like OccupancyGrids.

Documentation of the offset parameter:
http://docs.scipy.org/doc/numpy/reference/generated/numpy.frombuffer.html
