### PR TITLE
pretty print non-ascii string in list-type message

### DIFF
--- a/src/genpy/message.py
+++ b/src/genpy/message.py
@@ -132,7 +132,7 @@ def strify_message(val, indent='', time_offset=None, current_time=None, field_fi
             return list_str
         elif type(val0) in (int, float, str, bool):
             # TODO: escape strings properly
-            return str(list(val))
+            return repr(list(val)).decode('string-escape')
         else:
             pref = indent + '- '
             indent = indent + '  '


### PR DESCRIPTION
By this change, we can see non-ascii string human readably in list-type or tuple-type message.

test script:

- run the script that publishes non-ascii string.

```python
# test.py
# -*- coding: utf-8 -*-

import rospy
from test.msg import StringArray # this message has string[] data

rospy.init_node("foo")
pub = rospy.Publisher("/string", StringArray)
while not rospy.is_shutdown():
    msg = StringArray()
    msg.data = ["ほげ", "ふが", "ბარ", "кот", "foo"]
    pub.publish(msg)
    rospy.sleep(1.0)
```

```bash
$ roscore &
$ python test.py
```

- in another terminal, `rostopic echo`

**BEFORE**

```bash
$ rostopic echo /string
data: ['\xe3\x81\xbb\xe3\x81\x92', '\xe3\x81\xb5\xe3\x81\x8c', '\xe1\x83\x91\xe1\x83\x90\xe1\x83\xa0', '\xd0\xba\xd0\xbe\xd1\x82', 'foo']
---
```

**AFTER**

```bash
$ rostopic echo /string
data: ['ほげ', 'ふが', 'ბარ', 'кот', 'foo']
---
```