### PR TITLE
fix Duration.abs() when sec is zero and add a test for it

### DIFF
--- a/src/genpy/rostime.py
+++ b/src/genpy/rostime.py
@@ -346,7 +346,7 @@ class Duration(TVal):
         Absolute value of this duration
         :returns: positive :class:`Duration`
         """
-        if self.secs > 0:
+        if self.secs >= 0:
             return self
         return self.__neg__()
 

--- a/test/test_genpy_rostime.py
+++ b/test/test_genpy_rostime.py
@@ -387,6 +387,7 @@ class RostimeTest(unittest.TestCase):
         self.assertEquals(abs(Duration(-1)), Duration(1))
         self.assertEquals(abs(Duration(0,-1)), Duration(0,1))
         self.assertEquals(abs(Duration(-1,-1)), Duration(1,1))
+        self.assertEquals(abs(Duration(0,1)), Duration(0,1))
         
         # Duration (float secs) vs. Duration(int, int)
         self.assertEquals(Duration.from_sec(0.5), Duration(0.5))


### PR DESCRIPTION
Addresses #35.

@esteve @tfoote @wjwwood Please review.