### PR TITLE
fix reference modification in generate_dynamic

### DIFF
--- a/src/genpy/dynamic.py
+++ b/src/genpy/dynamic.py
@@ -95,7 +95,7 @@ def _gen_dyn_modify_references(py_text, current_type, types):
         # - remove any import statements
         py_text = py_text.replace("import %s.msg"%pkg, '')
         # - rewrite any references to class
-        py_text = re.sub("(?<!\w)%s.msg.%s(?!\w)"%(pkg, base_type), gen_name, py_text)
+        py_text = re.sub("(?<!\w)%s\.msg\.%s(?!\w)"%(pkg, base_type), gen_name, py_text)
 
     pkg, base_type = genmsg.package_resource_name(current_type)
     gen_name = _gen_dyn_name(pkg, base_type)

--- a/src/genpy/dynamic.py
+++ b/src/genpy/dynamic.py
@@ -46,6 +46,7 @@ import os
 import shutil
 import sys
 import tempfile
+import re
 
 import genmsg
 import genmsg.msg_loader
@@ -94,7 +95,7 @@ def _gen_dyn_modify_references(py_text, current_type, types):
         # - remove any import statements
         py_text = py_text.replace("import %s.msg"%pkg, '')
         # - rewrite any references to class
-        py_text = py_text.replace("%s.msg.%s"%(pkg, base_type), gen_name)
+        py_text = re.sub("(?<!\w)%s.msg.%s(?!\w)"%(pkg, base_type), gen_name, py_text)
 
     pkg, base_type = genmsg.package_resource_name(current_type)
     gen_name = _gen_dyn_name(pkg, base_type)


### PR DESCRIPTION
Reference modification in `generate_dynamic` can fail in certain cases.

Consider a custom message `my_geometry_msgs/Vector3WithCovariance` consisting of

    geometry_msgs/Vector3 vector
    float64[9]            covariance

When modifying the references in `generate_dynamic`, there is an erroneous match for my_**geometry_msgs.msg.Vector3**WithCovariance, which results in a wrong symbol after replacement (`my__geometry_msgs__Vector3WithCovariance` instead of `_my_geometry_msgs__Vector3WithCovariance`).

This happens because the currently used string replacement strategy is too simplistic. It does not check if it is actually replacing a full symbol.