### PR TITLE
Please make generated __init__.py files reproduducible

### DIFF
--- a/src/genpy/generate_initpy.py
+++ b/src/genpy/generate_initpy.py
@@ -48,7 +48,7 @@ def write_modules(outdir):
         return 0
     types_in_dir = set([f[1:-3] for f in os.listdir(outdir)
                      if f.endswith('.py') and f != '__init__.py'])
-    generated_modules = [_module_name(f) for f in types_in_dir]
+    generated_modules = [_module_name(f) for f in sorted(types_in_dir)]
     write_module(outdir, generated_modules)
     return 0
 


### PR DESCRIPTION
Whilst working on the "reproducible builds" effort [0], we noticed that
genpy generates output with a non-determistic order.

The attached patch removes this randomness from the build system. Once
applied, packages using python-genpy can be built reproducibly using our
reproducible toolchain.

 [0] https://wiki.debian.org/ReproducibleBuilds

Signed-off-by: Chris Lamb <chris@chris-lamb.co.uk>