### PR TITLE
Align the nsecs field of the timestamps.

### DIFF
--- a/src/genpy/message.py
+++ b/src/genpy/message.py
@@ -121,7 +121,7 @@ def strify_message(val, indent='', time_offset=None, current_time=None, field_fi
             nsec_str = '\n%snsecs: ' % indent + (format_str % val.nsecs)
             return sec_str + nsec_str
         else:
-            return '\n%ssecs: %s\n%snsecs: %s'%(indent, val.secs, indent, val.nsecs)
+            return '\n%ssecs: %s\n%snsecs: %9d'%(indent, val.secs, indent, val.nsecs)
         
     elif type_ in (list, tuple):
         if len(val) == 0:


### PR DESCRIPTION
This change ensures that the nsecs field is always right aligned such that the least significant digit of the  secs field aligns with the least significant digit of the secs field. This makes it easier to inspect how far into the second the time has progressed.

Before:
```
  stamp: 
    secs: 1450885486
    nsecs: 3398683
```
After:
```
  stamp: 
    secs: 1450885486
    nsecs:   3398683
```

A minor aesthetic change, but this makes it easier to look for the start of a certain second, as well as easier to read because the values of the same significance are always on the same position.

Hopefully it doesn't break anyone's scripts relying on the output; there still is always a space after the semicolon, but below the 100ms there are multiple spaces between the semicolon and the number.