### PR TITLE
Update regression test for nsecs alignment.

### DIFF
--- a/test/test_genpy_message.py
+++ b/test/test_genpy_message.py
@@ -562,10 +562,10 @@ list: []""", strify_message(M2('', -1, 0., False, [])))
                 self.d = d        
         self.assertEquals("""t: 
   secs: 987
-  nsecs: 654
+  nsecs:       654
 d: 
   secs: 123
-  nsecs: 456""", strify_message(M5(Time(987, 654), Duration(123, 456))))
+  nsecs:       456""", strify_message(M5(Time(987, 654), Duration(123, 456))))
         
         # test final clause of strify -- str anything that isn't recognized
         if sys.hexversion > 0x03000000:  # Python3


### PR DESCRIPTION
The alignment of the nsecs field was changed in ros/genpy@edb9c5abf2b4fe7d716ae8fa72cceb24717b0035
(pull request ros/genpy#45), this caused the regression test for
the timestamp field to fail.

This commit updates the comparison value of the regression tests to reflect
the new alignment.
