### PR TITLE
Don't use argument unpacking on strings

### DIFF
--- a/src/genpy/generator.py
+++ b/src/genpy/generator.py
@@ -429,10 +429,7 @@ def string_serializer_generator(package, type_, name, serialize):
             yield INDENT+"%s = %s.encode('utf-8')"%(var,var) #For unicode-strings in Python2, encode using utf-8
             yield INDENT+"length = len(%s)"%(var) # Update the length after utf-8 conversion
 
-            yield "if python3:"
-            yield INDENT+pack2("'<I%sB'%length", "length, *%s"%var)
-            yield "else:"
-            yield INDENT+pack2("'<I%ss'%length", "length, %s"%var)
+            yield pack2("'<I%ss'%length", "length, %s"%var)
     else:
         yield "start = end"
         if array_len is not None:

--- a/src/genpy/generator.py
+++ b/src/genpy/generator.py
@@ -143,7 +143,6 @@ def default_value(msg_context, field_type, default_package):
     elif field_type in ['float32', 'float64']:
         return '0.'
     elif field_type == 'string':
-        # strings, char[], and uint8s are all optimized to be strings
         return "''"
     elif field_type == 'bool':
         return 'False'
@@ -152,9 +151,9 @@ def default_value(msg_context, field_type, default_package):
         if base_type in ['char', 'uint8']:
             # strings, char[], and uint8s are all optimized to be strings
             if array_len is not None:
-                return "chr(0)*%s"%array_len
+                return r"b'\0'*%s"%array_len
             else:
-                return "''"
+                return "b''"
         elif array_len is None: #var-length
             return '[]'
         else: # fixed-length, fill values

--- a/test/files/array/string_varlen_ser.txt
+++ b/test/files/array/string_varlen_ser.txt
@@ -5,7 +5,4 @@ for val0 in data:
   if python3 or type(val0) == unicode:
     val0 = val0.encode('utf-8')
     length = len(val0)
-  if python3:
-    buff.write(struct.pack('<I%sB'%length, length, *val0))
-  else:
-    buff.write(struct.pack('<I%ss'%length, length, val0))
+  buff.write(struct.pack('<I%ss'%length, length, val0))

--- a/test/test_genpy_generator.py
+++ b/test/test_genpy_generator.py
@@ -156,7 +156,7 @@ def test_default_value():
         assert '[]' == val, "[%s]: %s"%(t, val)
         assert '[]' == default_value(msg_context, t+'[]', 'roslib')
 
-    assert "''" == default_value(msg_context, 'uint8[]', 'roslib')
+    assert b'' == eval(default_value(msg_context, 'uint8[]', 'roslib'))
 
     # fixed-length arrays should be zero-filled... except for byte and uint8 which are strings
     for t in ['float32', 'float64']:
@@ -166,8 +166,8 @@ def test_default_value():
         assert '[0,0,0,0]' == default_value(msg_context, t+'[4]', 'std_msgs')
         assert '[0]' == default_value(msg_context, t+'[1]', 'roslib')
 
-    assert "chr(0)*1" == default_value(msg_context, 'uint8[1]', 'roslib')
-    assert "chr(0)*4" == default_value(msg_context, 'uint8[4]', 'roslib')
+    assert b'\0' == eval(default_value(msg_context, 'uint8[1]', 'roslib'))
+    assert b'\0\0\0\0' == eval(default_value(msg_context, 'uint8[4]', 'roslib'))
 
     assert '[]' == default_value(msg_context, 'fake_msgs/String[]', 'std_msgs')
     assert '[fake_msgs.msg.String(),fake_msgs.msg.String()]' == default_value(msg_context, 'fake_msgs/String[2]', 'std_msgs')

--- a/test/test_genpy_generator.py
+++ b/test/test_genpy_generator.py
@@ -296,10 +296,7 @@ def test_string_serializer_generator():
 if python3 or type(var_name) == unicode:
   var_name = var_name.encode('utf-8')
   length = len(var_name)
-if python3:
-  buff.write(struct.pack('<I%sB'%length, length, *var_name))
-else:
-  buff.write(struct.pack('<I%ss'%length, length, var_name))""" == val, val
+buff.write(struct.pack('<I%ss'%length, length, var_name))""" == val, val
 
     for t in ['uint8[]', 'byte[]', 'uint8[10]', 'byte[20]']:
         g = genpy.generator.string_serializer_generator('foo', 'uint8[]', 'b_name', True)


### PR DESCRIPTION
`struct.pack('5s', b'abcde')` works just fine for me on 3.5.0. Argument unpacking a string is going to be a big performance hit for long strings too