### PR TITLE
warn about using floor division of durations

### DIFF
--- a/src/genpy/rostime.py
+++ b/src/genpy/rostime.py
@@ -35,6 +35,7 @@ ROS Time representation, including Duration
 """
 
 import sys
+import warnings
 
 if sys.version > '3': 
     long = int
@@ -395,6 +396,12 @@ class Duration(TVal):
         """
         t = type(val)
         if t in (int, long):
+            warnings.warn(
+                'The Duration.__floordiv__(integer) function is ill-defined. '
+                'The floor operation is applied independently on the seconds as well as the nanoseconds. '
+                'For rounding down to the nearest second use a float divisor. '
+                'For true division use the operator `/` (which requires `from __future__ import division` in Python 2) or `operator.truediv` instead.',
+                category=RuntimeWarning)
             return Duration(self.secs // val, self.nsecs // val)
         elif t == float:
             return Duration.from_sec(self.to_sec() // val)
@@ -413,6 +420,11 @@ class Duration(TVal):
         # PEP 238
         t = type(val)
         if t in (int, long):
+            warnings.warn(
+                'The Duration.__div__(integer) function is ill-defined. '
+                'The floor operation is applied independently on the seconds as well as the nanoseconds. '
+                'For true division use a float divisor or `from __future__ import division` in Python 2 or `operator.truediv` instead.',
+                category=RuntimeWarning)
             return Duration(self.secs // val, self.nsecs // val)
         elif t == float:
             return Duration.from_sec(self.to_sec() / val)

--- a/test/test_genpy_rostime.py
+++ b/test/test_genpy_rostime.py
@@ -31,6 +31,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 import unittest
+import warnings
 
 class RostimeTest(unittest.TestCase):
   
@@ -414,16 +415,30 @@ class RostimeTest(unittest.TestCase):
         # Test div
         self.assertEquals(Duration(4), Duration(8) / 2)
         self.assertEquals(Duration(4), Duration(8) / 2.)      
-        self.assertEquals(Duration(4), Duration(8) // 2)      
-        self.assertEquals(Duration(4), Duration(8) // 2.)      
-        self.assertEquals(Duration(4), Duration(9) // 2)      
-        self.assertEquals(Duration(4), Duration(9) // 2.)      
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            self.assertEquals(Duration(4), Duration(8) // 2)
+            self.assertEqual(len(w), 1)
+            self.assert_(issubclass(w[-1].category, RuntimeWarning))
+            self.assertEquals(Duration(4), Duration(8) // 2.)
+            self.assertEqual(len(w), 1)
+            self.assertEquals(Duration(4), Duration(9) // 2)
+            self.assertEqual(len(w), 2)
+            self.assert_(issubclass(w[-1].category, RuntimeWarning))
+            self.assertEquals(Duration(4), Duration(9) // 2.)
+            self.assertEqual(len(w), 2)
         self.assertEquals(Duration(4, 2), Duration(8, 4) / 2)
         v = Duration(4, 2) - (Duration(8, 4) / 2.)
         self.assert_(abs(v.to_nsec()) < 100)            
         
-        self.assertEquals(Duration(4, 2), Duration(8, 4) // 2)
-        self.assertEquals(Duration(4, 2), Duration(9, 5) // 2)
-        v = Duration(4, 2) - (Duration(9, 5) // 2.)
-        self.assert_(abs(v.to_nsec()) < 100)                  
-        
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            self.assertEquals(Duration(4, 2), Duration(8, 4) // 2)
+            self.assertEqual(len(w), 1)
+            self.assert_(issubclass(w[-1].category, RuntimeWarning))
+            self.assertEquals(Duration(4, 2), Duration(9, 5) // 2)
+            self.assertEqual(len(w), 2)
+            self.assert_(issubclass(w[-1].category, RuntimeWarning))
+            v = Duration(4, 2) - (Duration(9, 5) // 2.)
+            self.assert_(abs(v.to_nsec()) < 100)
+            self.assertEqual(len(w), 2)


### PR DESCRIPTION
Fixes #49.

This adds a `RuntimeWarning` for using floor division with integer dividers. Imo it is reasonable to add this warning to all supported distros since it is informing the user that something unexpected is going on. I don't see a use case where this behavior is actually intended. If existing code currently uses this it will result in a warning and the code an easily be updated.

Regarding the question if the class should always implement true division (for all or only newer ROS distros): Python has the same situation when doing integer division. Some might call it really bad default behavior but that's how Python does it. And there is a clean way (`from __future__ import division`) to explicitly use true division (which is the same across division operations across various types). Therefore I think it is reasonable to not change the current implementation.

A division by float already does a true division. And if the user requests an explicit float division that is what he wants. The fact that is performs the floor on seconds is reasonable imo. Updating the integer version of the function to return a more similar result is not necessary since the recommendation is to not use the function in the first place.

@ros/ros_team @eric-wieser Please review this carefully to be considered for merge and release as mentioned.