### PR TITLE
fix default value of lists to not expand to N items in the generated code

### DIFF
--- a/src/genpy/generator.py
+++ b/src/genpy/generator.py
@@ -158,7 +158,7 @@ def default_value(msg_context, field_type, default_package):
             return '[]'
         else: # fixed-length, fill values
             def_val = default_value(msg_context, base_type, default_package)
-            return '[' + ','.join(itertools.repeat(def_val, array_len)) + ']'
+            return '[' + def_val + '] * ' + str(array_len)
     else:
         return compute_constructor(msg_context, default_package, field_type)
 

--- a/test/test_genpy_generator.py
+++ b/test/test_genpy_generator.py
@@ -160,17 +160,17 @@ def test_default_value():
 
     # fixed-length arrays should be zero-filled... except for byte and uint8 which are strings
     for t in ['float32', 'float64']:
-        assert '[0.,0.,0.]' == default_value(msg_context, t+'[3]', 'std_msgs')
-        assert '[0.]' == default_value(msg_context, t+'[1]', 'std_msgs')
+        assert '[0.] * 3' == default_value(msg_context, t+'[3]', 'std_msgs')
+        assert '[0.] * 1' == default_value(msg_context, t+'[1]', 'std_msgs')
     for t in ['int8', 'uint16', 'int16', 'uint32', 'int32', 'uint64', 'int64']:
-        assert '[0,0,0,0]' == default_value(msg_context, t+'[4]', 'std_msgs')
-        assert '[0]' == default_value(msg_context, t+'[1]', 'roslib')
+        assert '[0] * 4' == default_value(msg_context, t+'[4]', 'std_msgs')
+        assert '[0] * 1' == default_value(msg_context, t+'[1]', 'roslib')
 
     assert b'\0' == eval(default_value(msg_context, 'uint8[1]', 'roslib'))
     assert b'\0\0\0\0' == eval(default_value(msg_context, 'uint8[4]', 'roslib'))
 
     assert '[]' == default_value(msg_context, 'fake_msgs/String[]', 'std_msgs')
-    assert '[fake_msgs.msg.String(),fake_msgs.msg.String()]' == default_value(msg_context, 'fake_msgs/String[2]', 'std_msgs')
+    assert '[fake_msgs.msg.String()] * 2' == default_value(msg_context, 'fake_msgs/String[2]', 'std_msgs')
 
 def test_make_python_safe():
     from genpy.generator import make_python_safe


### PR DESCRIPTION
For an example field `uint32[10] foo` the generated code look as follows:

Without this patch: `self.foo = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]`

With this patch: `self.foo = [0] * 10`

And now imagine `N` being `134217728` as in ros/ros_comm#808 :bomb:

I would propose to also backport this patch to Indigo and Jade after it has been merged.