### PR TITLE
lazy init struct

### DIFF
--- a/src/genpy/generate_struct.py
+++ b/src/genpy/generate_struct.py
@@ -120,7 +120,7 @@ def pack(pattern, vars):
     # - store pattern in context
     pattern = reduce_pattern(pattern)
     add_pattern(pattern)
-    return serialize("_struct_%s.pack(%s)"%(pattern, vars))
+    return serialize("_struct_%s().pack(%s)"%(pattern, vars))
 def pack2(pattern, vars):
     """
     create struct.pack call for when pattern is the name of a variable
@@ -139,7 +139,7 @@ def unpack(var, pattern, buff):
     # - store pattern in context
     pattern = reduce_pattern(pattern)
     add_pattern(pattern)
-    return var + " = _struct_%s.unpack(%s)"%(pattern, buff)
+    return var + " = _struct_%s().unpack(%s)"%(pattern, buff)
 
 def unpack2(var, pattern, buff):
     """

--- a/src/genpy/generator.py
+++ b/src/genpy/generator.py
@@ -881,7 +881,12 @@ def msg_generator(msg_context, spec, search_path):
         if p == 'I':
             continue
         var_name = '_struct_%s'%(p.replace('<',''))
-        yield '%s = struct.Struct("<%s")'%(var_name, p)
+        yield '_%s = None' % var_name
+        yield 'def %s():' % var_name
+        yield '    global _%s' % var_name
+        yield '    if _%s is None:' % var_name
+        yield '        _%s = struct.Struct("<%s")' % (var_name, p)
+        yield '    return _%s' % var_name
     clear_patterns()
 
 def srv_generator(msg_context, spec, search_path):

--- a/test/files/array/bool_fixed_deser.txt
+++ b/test/files/array/bool_fixed_deser.txt
@@ -1,4 +1,4 @@
 start = end
 end += 3
-data = _struct_3B.unpack(str[start:end])
+data = _struct_3B().unpack(str[start:end])
 data = map(bool, data)

--- a/test/files/array/bool_fixed_ser.txt
+++ b/test/files/array/bool_fixed_ser.txt
@@ -1,1 +1,1 @@
-buff.write(_struct_3B.pack(*data))
+buff.write(_struct_3B().pack(*data))

--- a/test/files/array/int16_fixed_deser.txt
+++ b/test/files/array/int16_fixed_deser.txt
@@ -1,3 +1,3 @@
 start = end
 end += 20
-data = _struct_10h.unpack(str[start:end])
+data = _struct_10h().unpack(str[start:end])

--- a/test/files/array/int16_fixed_ser.txt
+++ b/test/files/array/int16_fixed_ser.txt
@@ -1,1 +1,1 @@
-buff.write(_struct_10h.pack(*data))
+buff.write(_struct_10h().pack(*data))

--- a/test/files/array/object_fixed_deser.txt
+++ b/test/files/array/object_fixed_deser.txt
@@ -3,5 +3,5 @@ for i in range(0, 3):
   val0 = foo.msg.Object()
   start = end
   end += 4
-  (val0.data,) = _struct_i.unpack(str[start:end])
+  (val0.data,) = _struct_i().unpack(str[start:end])
   data.append(val0)

--- a/test/files/array/object_fixed_ser.txt
+++ b/test/files/array/object_fixed_ser.txt
@@ -1,2 +1,2 @@
 for val0 in data:
-  buff.write(_struct_i.pack(val0.data))
+  buff.write(_struct_i().pack(val0.data))

--- a/test/files/array/object_varlen_deser.txt
+++ b/test/files/array/object_varlen_deser.txt
@@ -6,5 +6,5 @@ for i in range(0, length):
   val0 = foo.msg.Object()
   start = end
   end += 4
-  (val0.data,) = _struct_i.unpack(str[start:end])
+  (val0.data,) = _struct_i().unpack(str[start:end])
   data.append(val0)

--- a/test/files/array/object_varlen_ser.txt
+++ b/test/files/array/object_varlen_ser.txt
@@ -1,4 +1,4 @@
 length = len(data)
 buff.write(_struct_I.pack(length))
 for val0 in data:
-  buff.write(_struct_i.pack(val0.data))
+  buff.write(_struct_i().pack(val0.data))

--- a/test/files/array/object_varlen_ser_full.txt
+++ b/test/files/array/object_varlen_ser_full.txt
@@ -2,6 +2,6 @@ try:
   length = len(self.array)
   buff.write(_struct_I.pack(length))
   for val1 in self.array:
-    buff.write(_struct_i.pack(val1.data))
+    buff.write(_struct_i().pack(val1.data))
 except struct.error as se: self._check_types(struct.error("%s: '%s' when writing '%s'" % (type(se), str(se), str(locals().get('_x', self)))))
 except TypeError as te: self._check_types(ValueError("%s: '%s' when writing '%s'" % (type(te), str(te), str(locals().get('_x', self)))))

--- a/test/files/array/uint8_fixed_ser.txt
+++ b/test/files/array/uint8_fixed_ser.txt
@@ -1,5 +1,5 @@
 # - if encoded as a list instead, serialize as bytes instead of string
 if type(data) in [list, tuple]:
-  buff.write(_struct_8B.pack(*data))
+  buff.write(_struct_8B().pack(*data))
 else:
-  buff.write(_struct_8s.pack(data))
+  buff.write(_struct_8s().pack(data))

--- a/test/files/array/uint8_fixed_ser_np.txt
+++ b/test/files/array/uint8_fixed_ser_np.txt
@@ -1,5 +1,5 @@
 # - if encoded as a list instead, serialize as bytes instead of string
 if type(data) in [list, tuple]:
-  buff.write(_struct_8B.pack(*data))
+  buff.write(_struct_8B().pack(*data))
 else:
-  buff.write(_struct_8s.pack(data))
+  buff.write(_struct_8s().pack(data))

--- a/test/files/complex/object_ser.txt
+++ b/test/files/complex/object_ser.txt
@@ -1,2 +1,2 @@
 _v1 = data
-buff.write(_struct_i.pack(_v1.data))
+buff.write(_struct_i().pack(_v1.data))

--- a/test/files/complex/object_ser_full.txt
+++ b/test/files/complex/object_ser_full.txt
@@ -1,4 +1,4 @@
 try:
-  buff.write(_struct_i.pack(self.data))
+  buff.write(_struct_i().pack(self.data))
 except struct.error as se: self._check_types(struct.error("%s: '%s' when writing '%s'" % (type(se), str(se), str(locals().get('_x', self)))))
 except TypeError as te: self._check_types(ValueError("%s: '%s' when writing '%s'" % (type(te), str(te), str(locals().get('_x', self)))))

--- a/test/test_genpy_generate_struct.py
+++ b/test/test_genpy_generate_struct.py
@@ -17,7 +17,7 @@ def test_reduce_pattern():
 
 def test_pack():
     from genpy.generate_struct import pack
-    assert "buff.write(_struct_3lL3bB.pack(foo, bar))" == pack('lllLbbbB', 'foo, bar')
+    assert "buff.write(_struct_3lL3bB().pack(foo, bar))" == pack('lllLbbbB', 'foo, bar')
 
 def test_pack2():
     from genpy.generate_struct import pack2
@@ -25,7 +25,7 @@ def test_pack2():
 
 def test_unpack():
     from genpy.generate_struct import unpack
-    assert "var_x = _struct_I3if2I.unpack(bname)" == unpack('var_x', 'IiiifII', 'bname')
+    assert "var_x = _struct_I3if2I().unpack(bname)" == unpack('var_x', 'IiiifII', 'bname')
 
 def test_unpack2():
     from genpy.generate_struct import unpack2


### PR DESCRIPTION
While this doesn't prevent the high memory usage for data structures with large static arrays it at least defers the initialization of the `Struct` until it is actually being used.

Related to ros/ros_comm#808

While this *does* change the API in the generated modules there is no way to keep it a variable but initialize it on demand. And since the variable is considered private (leading underscore) hopefully nobody uses it.

I would propose to **not** backport this patch (due to the internal API change).