### PR TITLE
Add escaping for strings which is valid in YAML 

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -18,6 +18,7 @@
   <build_depend>genmsg</build_depend>
 
   <run_depend>genmsg</run_depend>
+  <run_depend>python-yaml</run_depend>
 
   <test_depend>python-yaml</test_depend>
 

--- a/package.xml
+++ b/package.xml
@@ -20,8 +20,6 @@
   <run_depend>genmsg</run_depend>
   <run_depend>python-yaml</run_depend>
 
-  <test_depend>python-yaml</test_depend>
-
   <export>
     <message_generator>py</message_generator>
     <rosdoc config="rosdoc.yaml"/>

--- a/src/genpy/message.py
+++ b/src/genpy/message.py
@@ -41,6 +41,7 @@ import math
 import itertools
 import struct
 import sys
+import yaml
 
 import genmsg
 
@@ -106,10 +107,10 @@ def strify_message(val, indent='', time_offset=None, current_time=None, field_fi
     elif type_ in (int, long, float, bool):
         return str(val)
     elif isstring(val):
-        #TODO: need to escape strings correctly
         if not val:
             return "''"
-        return val
+        # escape strings for use in yaml file using yaml dump
+        return yaml.dump(val).split('\n')[0]
     elif isinstance(val, TVal):
         
         if time_offset is not None and isinstance(val, Time):
@@ -130,8 +131,10 @@ def strify_message(val, indent='', time_offset=None, current_time=None, field_fi
         if type(val0) in (int, float) and fixed_numeric_width is not None:
             list_str = '[' + ''.join(strify_message(v, indent, time_offset, current_time, field_filter, fixed_numeric_width) + ', ' for v in val).rstrip(', ') + ']'
             return list_str
-        elif type(val0) in (int, float, str, bool):
-            # TODO: escape strings properly
+        elif isstring(val0):
+            # escape list of strings for use in yaml file using yaml dump
+            return yaml.dump(val).split('\n')[0]
+        elif type(val0) in (int, float, bool):
             return str(list(val))
         else:
             pref = indent + '- '

--- a/src/genpy/message.py
+++ b/src/genpy/message.py
@@ -109,8 +109,8 @@ def strify_message(val, indent='', time_offset=None, current_time=None, field_fi
     elif isstring(val):
         if not val:
             return "''"
-        # escape strings for use in yaml file using yaml dump
-        return yaml.dump(val).split('\n')[0]
+        # escape strings for use in yaml file using yaml dump with default style to avoid trailing "...\n"
+        return yaml.dump(val, default_style='"').rstrip('\n')
     elif isinstance(val, TVal):
         
         if time_offset is not None and isinstance(val, Time):
@@ -133,7 +133,7 @@ def strify_message(val, indent='', time_offset=None, current_time=None, field_fi
             return list_str
         elif isstring(val0):
             # escape list of strings for use in yaml file using yaml dump
-            return yaml.dump(val).split('\n')[0]
+            return yaml.dump(val).rstrip('\n')
         elif type(val0) in (int, float, bool):
             return str(list(val))
         else:

--- a/test/test_genpy_message.py
+++ b/test/test_genpy_message.py
@@ -578,15 +578,17 @@ d:
 
     def test_strify_yaml(self):
         def roundtrip(m):
+            print('\n\n\nroundtrip')
             yaml_text = strify_message(m)
-            print(yaml_text)
+            print('\nyaml: %s' % yaml_text)
             loaded = yaml.load(yaml_text) 
-            print("loaded", loaded)
+            print('\nloaded: %s' % loaded)
             new_inst = m.__class__()
             if loaded is not None:
                 fill_message_args(new_inst, [loaded])
             else:
                 fill_message_args(new_inst, [])                
+            print('\nnew_inst: %s' % new_inst)
             return new_inst
 
         # test YAML roundtrip. strify_message doesn't promise this
@@ -610,11 +612,17 @@ d:
                 self.str_list = str_list_
 
         # test with empty string and empty list
-        val = M2('', -1, 0., False, [], ['', ''])
+        val = M2('foo\nbar', -1, 0., False, [], ['', ''])
         self.assertEquals(val, roundtrip(val))
 
+        multiline_str = """
+foo bar
+foo # bar
+foo ' bar
+foo " bar
+        """
         # test with strings and list of strings that need escaping
-        val = M2('"foo \' bar" # foobar', 123456789101112, 5678., True, [1,2,3], ['foo # bar', '"foo \' bar"', '"foo" \" # \' \" bar'])
+        val = M2(multiline_str, 123456789101112, 5678., True, [1,2,3], [multiline_str, 'foo \n # bar\n', '"foo \' bar"', '"foo" \" # \' \" bar'])
         self.assertEquals(val, roundtrip(val))
 
         class M3(Message):

--- a/test/test_genpy_message.py
+++ b/test/test_genpy_message.py
@@ -578,17 +578,15 @@ d:
 
     def test_strify_yaml(self):
         def roundtrip(m):
-            #print('\n\n\nroundtrip')
             yaml_text = strify_message(m)
-            #print('\nyaml: %s' % yaml_text)
-            loaded = yaml.load(yaml_text) 
-            #print('\nloaded: %s' % loaded)
+            print(yaml_text)
+            loaded = yaml.load(yaml_text)
+            print("loaded", loaded)
             new_inst = m.__class__()
             if loaded is not None:
                 fill_message_args(new_inst, [loaded])
             else:
                 fill_message_args(new_inst, [])                
-            #print('\nnew_inst: %s' % new_inst)
             return new_inst
 
         # test YAML roundtrip. strify_message doesn't promise this

--- a/test/test_genpy_message.py
+++ b/test/test_genpy_message.py
@@ -599,28 +599,32 @@ d:
         self.assertEquals(M1(), roundtrip(M1()))
         
         class M2(Message):
-            __slots__ = ['str', 'int', 'float', 'bool', 'list']
-            _slot_types = ['string', 'int32', 'float32', 'bool', 'int32[]'] 
-            def __init__(self, str_=None, int_=None, float_=None, bool_=None, list_=None):
+            __slots__ = ['str', 'int', 'float', 'bool', 'list', 'str_list']
+            _slot_types = ['string', 'int32', 'float32', 'bool', 'int32[]', 'string[]']
+            def __init__(self, str_=None, int_=None, float_=None, bool_=None, list_=None, str_list_=None):
                 self.str = str_
                 self.int = int_       
                 self.float = float_
                 self.bool = bool_
                 self.list = list_
-                
-        val = M2('string', 123456789101112, 5678., True, [1,2,3])
-        self.assertEquals(val, roundtrip(val))
+                self.str_list = str_list_
+
         # test with empty string and empty list
-        val = M2('', -1, 0., False, [])
+        val = M2('', -1, 0., False, [], ['', ''])
         self.assertEquals(val, roundtrip(val))
-        
+
+        # test with strings and list of strings that need escaping
+        val = M2('"foo \' bar" # foobar', 123456789101112, 5678., True, [1,2,3], ['foo # bar', '"foo \' bar"', '"foo" \" # \' \" bar'])
+        self.assertEquals(val, roundtrip(val))
+
         class M3(Message):
             __slots__ = ['m2']
             _slot_types=['test_roslib/M2']
             def __init__(self, m2=None):
                 self.m2 = m2 or M2()
-                
-        val = M3(M2('string', -1, 0., False, []))
+
+        # test with nested complex message
+        val = M3(val)
         self.assertEquals(val, roundtrip(val))
 
     def test_check_type(self):

--- a/test/test_genpy_message.py
+++ b/test/test_genpy_message.py
@@ -508,7 +508,7 @@ class MessageTest(unittest.TestCase):
                 self.bool = bool_
                 self.list = list_
                 
-        self.assertEquals("""str: string
+        self.assertEquals("""str: "string"
 int: 123456789101112
 float: 5678.0
 bool: True
@@ -526,7 +526,7 @@ list: []""", strify_message(M2('', -1, 0., False, [])))
             def __init__(self, m2):
                 self.m2 = m2
         self.assertEquals("""m2: 
-  str: string
+  str: "string"
   int: -1
   float: 0.0
   bool: False
@@ -541,13 +541,13 @@ list: []""", strify_message(M2('', -1, 0., False, [])))
                 
         self.assertEquals("""m2s: 
   - 
-    str: string
+    str: "string"
     int: 1234
     float: 5678.0
     bool: True
     list: [1, 2, 3]
   - 
-    str: string
+    str: "string"
     int: -1
     float: 0.0
     bool: False
@@ -578,17 +578,17 @@ d:
 
     def test_strify_yaml(self):
         def roundtrip(m):
-            print('\n\n\nroundtrip')
+            #print('\n\n\nroundtrip')
             yaml_text = strify_message(m)
-            print('\nyaml: %s' % yaml_text)
+            #print('\nyaml: %s' % yaml_text)
             loaded = yaml.load(yaml_text) 
-            print('\nloaded: %s' % loaded)
+            #print('\nloaded: %s' % loaded)
             new_inst = m.__class__()
             if loaded is not None:
                 fill_message_args(new_inst, [loaded])
             else:
                 fill_message_args(new_inst, [])                
-            print('\nnew_inst: %s' % new_inst)
+            #print('\nnew_inst: %s' % new_inst)
             return new_inst
 
         # test YAML roundtrip. strify_message doesn't promise this


### PR DESCRIPTION
Feeding output of "rostopic echo" back into "rostopic pub" does not work properly with strings containing characters which have special meaning in YAML (e.g. '#', "'" or '"').
These chars should be escaped properly to make the output of "rostopic echo" and the string representation of messages in general valid YAML code.

Strings are not properly escaped in strify_message, so publishing a string like e.g. 'foo # bar':
```
$ rostopic pub -1 /string std_msgs/String "data: 'foo # bar'"
```
results in YAML code where the string only contains "foo " and "# bar" is treated as a comment, changing the data without even raising an error:
```
$ rostopic echo /string
data: foo # bar
---
```
After applying this PR the correct result is printed
```
$ rostopic echo /string
data: 'foo # bar'
---
```

This also holds for enclosed "'" and '"' characters.
To test this I also updated the test_strify_yaml to check for proper escaping.
