### PR TITLE
Add optional string escaping in strify_message

### DIFF
--- a/src/genpy/message.py
+++ b/src/genpy/message.py
@@ -81,7 +81,7 @@ class SerializationError(MessageException):
 
 # we expose the generic message-strify routine for fn-oriented code like rostopic
 
-def strify_message(val, indent='', time_offset=None, current_time=None, field_filter=None, fixed_numeric_width=None):
+def strify_message(val, indent='', time_offset=None, current_time=None, field_filter=None, fixed_numeric_width=None, escape_strings=False):
     """
     Convert value to string representation
     :param val: to convert to string representation. Most likely a Message.  ``Value``
@@ -106,9 +106,10 @@ def strify_message(val, indent='', time_offset=None, current_time=None, field_fi
     elif type_ in (int, long, float, bool):
         return str(val)
     elif isstring(val):
-        #TODO: need to escape strings correctly
         if not val:
             return "''"
+        if escape_strings:
+            return '>-\n%s  %s' % (indent, val)
         return val
     elif isinstance(val, TVal):
         
@@ -128,15 +129,18 @@ def strify_message(val, indent='', time_offset=None, current_time=None, field_fi
             return "[]"
         val0 = val[0]
         if type(val0) in (int, float) and fixed_numeric_width is not None:
-            list_str = '[' + ''.join(strify_message(v, indent, time_offset, current_time, field_filter, fixed_numeric_width) + ', ' for v in val).rstrip(', ') + ']'
+            list_str = '[' + ''.join(strify_message(v, indent, time_offset, current_time, field_filter, fixed_numeric_width, escape_strings) + ', ' for v in val).rstrip(', ') + ']'
+            return list_str
+        elif type(val0) in (str,) and escape_strings:
+            line_prefix = '\n%s- ' % indent
+            list_str = line_prefix + line_prefix.join(strify_message(v, indent, time_offset, current_time, field_filter, fixed_numeric_width, escape_strings) for v in val)
             return list_str
         elif type(val0) in (int, float, str, bool):
-            # TODO: escape strings properly
             return str(list(val))
         else:
             pref = indent + '- '
             indent = indent + '  '
-            return '\n'+'\n'.join([pref+strify_message(v, indent, time_offset, current_time, field_filter, fixed_numeric_width) for v in val])
+            return '\n'+'\n'.join([pref+strify_message(v, indent, time_offset, current_time, field_filter, fixed_numeric_width, escape_strings) for v in val])
     elif isinstance(val, Message):
         # allow caller to select which fields of message are strified
         if field_filter is not None:
@@ -148,10 +152,10 @@ def strify_message(val, indent='', time_offset=None, current_time=None, field_fi
         ni = '  '+indent
         if sys.hexversion > 0x03000000: #Python3
             vals = '\n'.join([p%(f,
-                                 strify_message(_convert_getattr(val, f, t), ni, time_offset, current_time, field_filter, fixed_numeric_width)) for f,t in zip(val.__slots__, val._slot_types) if f in fields])			
+                                 strify_message(_convert_getattr(val, f, t), ni, time_offset, current_time, field_filter, fixed_numeric_width, escape_strings)) for f,t in zip(val.__slots__, val._slot_types) if f in fields])
         else: #Python2
             vals = '\n'.join([p%(f,
-                                 strify_message(_convert_getattr(val, f, t), ni, time_offset, current_time, field_filter, fixed_numeric_width)) for f,t in itertools.izip(val.__slots__, val._slot_types) if f in fields])
+                                 strify_message(_convert_getattr(val, f, t), ni, time_offset, current_time, field_filter, fixed_numeric_width, escape_strings)) for f,t in itertools.izip(val.__slots__, val._slot_types) if f in fields])
         if indent:
             return '\n'+vals
         else:

--- a/test/test_genpy_message.py
+++ b/test/test_genpy_message.py
@@ -577,8 +577,8 @@ d:
             self.assertEquals("set([1])", strify_message(set([1])))
 
     def test_strify_yaml(self):
-        def roundtrip(m):
-            yaml_text = strify_message(m)
+        def roundtrip(m, escape_strings=False):
+            yaml_text = strify_message(m, escape_strings=escape_strings)
             print(yaml_text)
             loaded = yaml.load(yaml_text) 
             print("loaded", loaded)
@@ -613,6 +613,9 @@ d:
         # test with empty string and empty list
         val = M2('', -1, 0., False, [])
         self.assertEquals(val, roundtrip(val))
+        # test with escaping
+        val = M2('illegal: plain #style', -1, 0., False, [])
+        self.assertEquals(val, roundtrip(val, escape_strings=True))
         
         class M3(Message):
             __slots__ = ['m2']


### PR DESCRIPTION
String escaping has been a TODO comment in the code for a long time. Since I need this feature now, here is my suggested implementation.

I suggest to use the [YAML Folded Style](http://yaml.org/spec/1.2/spec.html#id2796251) for escaping strings as this is the most robust format. Escaping is turned off by default to not change the look of terminal outputs like produced by `rostopic echo`. If turned on, any content of string message fields is possible and the output of `strify_message(msg, escape_strings=True)` can be used for `yaml.load` (see added test case).

Let me know what you think and if you see any problems.