### PR TITLE
msg check_type: uint8/char array in a msg is a byte array not str

### DIFF
--- a/src/genpy/message.py
+++ b/src/genpy/message.py
@@ -241,7 +241,7 @@ def check_type(field_name, field_type, field_val):
         # use index to generate error if '[' not present
         base_type = field_type[:field_type.index('[')]
 
-        if type(field_val) == str:
+        if type(field_val) == bytes:
             if not base_type in ['char', 'uint8']:
                 raise SerializationError('field %s must be a list or tuple type. Only uint8[] can be a string' % field_name);
             else:

--- a/src/genpy/message.py
+++ b/src/genpy/message.py
@@ -241,7 +241,7 @@ def check_type(field_name, field_type, field_val):
         # use index to generate error if '[' not present
         base_type = field_type[:field_type.index('[')]
 
-        if type(field_val) == bytes:
+        if type(field_val) in (str, bytes):
             if not base_type in ['char', 'uint8']:
                 raise SerializationError('field %s must be a list or tuple type. Only uint8[] can be a string' % field_name);
             else:


### PR DESCRIPTION
Doesn't matter for Python 2 since the types are equivalent.