### PR TITLE
Failing test case for UTF-8 encoded characters in comments

### DIFF
--- a/src/genpy/dynamic.py
+++ b/src/genpy/dynamic.py
@@ -165,7 +165,7 @@ def generate_dynamic(core_type, msg_cat):
     
     # write the entire text to a file and import it (it will get deleted when tmp_dir goes - above)
     tmp_file = tempfile.NamedTemporaryFile(suffix=".py",dir=tmp_dir,delete=False)
-    tmp_file.file.write(full_text.encode())
+    tmp_file.file.write(full_text)
     tmp_file.file.close()
 
     # import our temporary file as a python module, which requires modifying sys.path

--- a/src/genpy/dynamic.py
+++ b/src/genpy/dynamic.py
@@ -164,7 +164,7 @@ def generate_dynamic(core_type, msg_cat):
     atexit.register(shutil.rmtree, tmp_dir)
     
     # write the entire text to a file and import it (it will get deleted when tmp_dir goes - above)
-    tmp_file = tempfile.NamedTemporaryFile(suffix=".py",dir=tmp_dir,delete=False)
+    tmp_file = tempfile.NamedTemporaryFile(mode="w", suffix=".py", dir=tmp_dir, delete=False)
     tmp_file.file.write(full_text)
     tmp_file.file.close()
 

--- a/test/test_genpy_dynamic.py
+++ b/test/test_genpy_dynamic.py
@@ -51,6 +51,11 @@ def test_generate_dynamic():
     assert m_instance == m_instance2
 
     try:
+        msgs = generate_dynamic("gd_msgs/MyAcceleration", "float32 acceleration # in m/s\xc2\xb2\n")
+    except UnicodeDecodeError:
+        assert False, "Can't handle UTF-8 in comments"
+
+    try:
         char = unichr
     except NameError:
         char = chr


### PR DESCRIPTION
Addressing this issue: https://github.com/ros/genpy/issues/94

The proposed workaround probably makes the function accept any binary data in comments. Not sure, if this is universally acceptable.