### PR TITLE
Fix _convert_getattr for handling uint8[] message fields in Python 3

### DIFF
--- a/src/genpy/message.py
+++ b/src/genpy/message.py
@@ -171,6 +171,8 @@ def _convert_getattr(val, f, t):
     attr = getattr(val, f)
     if isstring(attr) and 'uint8[' in t:
         return [ord(x) for x in attr]
+    elif type(attr) == bytes and 'uint8[' in t:
+        return list(attr)
     else:
         return attr
 

--- a/src/genpy/message.py
+++ b/src/genpy/message.py
@@ -171,7 +171,7 @@ def _convert_getattr(val, f, t):
     attr = getattr(val, f)
     if isstring(attr) and 'uint8[' in t:
         return [ord(x) for x in attr]
-    elif type(attr) == bytes and 'uint8[' in t:
+    elif isinstance(attr, bytes) and 'uint8[' in t:
         return list(attr)
     else:
         return attr


### PR DESCRIPTION
In Python3, running `rostopic echo` on a message with a `uint8[]` field prints the field as a bytes type without conversion to a list of numbers:
```
$ rostopic pub  /test std_msgs/UInt8MultiArray "data: [1,2,3]"
```
```
$ rostopic echo /test
layout: 
  dim: []
  data_offset: 0
data: b'\x01\x02\x03'
```

We need to explicitly handle this case for Python 3 since `bytes` is not the same as `str` in Python 3 so the `isstring` check does not handle it.
This change does not affect Python 2 since the checks in the first and the new branch are equivalent in Python 2 so it would never take the new branch.