### PR TITLE
Make message parsing more robust

### DIFF
--- a/src/genpy/dynamic.py
+++ b/src/genpy/dynamic.py
@@ -60,6 +60,7 @@ def _generate_dynamic_specs(msg_context, specs, dep_msg):
     :returns: type name, message spec, ``str, MsgSpec``
     :raises: MsgGenerationException If dep_msg is improperly formatted
     """
+    dep_msg = dep_msg.strip()
     line1 = dep_msg.find('\n')
     msg_line = dep_msg[:line1]
     if not msg_line.startswith("MSG: "):


### PR DESCRIPTION
Using the latest ros:kinetic-robot docker image with some custom messages leads to the following error message, when reading the bag messages via the Python API:
`invalid input to generate_dynamic: dependent type is missing 'MSG:' type declaration header`

The culprit seems to be an empty line at the beginning of `dep_msg`.