### PR TITLE
Make the generated "struct" constructs reproducible

### DIFF
--- a/src/genpy/generator.py
+++ b/src/genpy/generator.py
@@ -876,7 +876,7 @@ def msg_generator(msg_context, spec, search_path):
     # rewritten to not use globals
     yield '_struct_I = genpy.struct_I'
     patterns = get_patterns()
-    for p in set(patterns):
+    for p in sorted(set(patterns)):
         # I patterns are already optimized
         if p == 'I':
             continue


### PR DESCRIPTION
Whilst working on the [Reproducible Builds](https://reproducible-builds.org/) effort we noticed that *genpy* generates unreproducible Python code output. This is currently affecting at least three packages in Debian `unstable`.

This commit ensures that the "struct" code stanzas are emitted in a deterministic order.

(This was originally filed in Debian as [#943694](https://bugs.debian.org/943694).)