### PR TITLE
Use setuptools instead of distutils

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -21,6 +21,7 @@
   <depend>genmsg</depend>
 
   <buildtool_depend version_gte="0.5.78">catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
 
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-yaml</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-yaml</exec_depend>

--- a/package.xml
+++ b/package.xml
@@ -22,6 +22,7 @@
 
   <buildtool_depend version_gte="0.5.78">catkin</buildtool_depend>
   <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-yaml</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-yaml</exec_depend>

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(


### PR DESCRIPTION
On Debian Buster and Ubuntu Focal [distutils has been split to a separate package](https://packages.debian.org/buster/python3-setuptools). With https://github.com/ros/catkin/pull/1048 catkin will prefer to use `setuptools` instead of `distutils`. Catkin [exports a buildtool depend for python3-setuptools](https://github.com/ros/catkin/blob/a3e97e4c7b34bded6e5055703f068e664ab88176/package.xml#L32), but it does not do the same for Python 2. Since this PR is targeting the `kinetic-devel` branch, it both switches to `setuptools` to match catkin's preference and adds a `<buildtool_depend>` on `python-setuptools` so it still works when `ROS_PYTHON_VERSION` is 2.
