### PR TITLE
Add check for float32 and float64 to check_type

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -24,6 +24,9 @@
   <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
   <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
+  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-numpy</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-numpy</exec_depend>
+
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-yaml</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-yaml</exec_depend>
 

--- a/package.xml
+++ b/package.xml
@@ -24,11 +24,11 @@
   <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
   <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
-  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-numpy</exec_depend>
-  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-numpy</exec_depend>
-
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-yaml</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-yaml</exec_depend>
+
+  <test_depend condition="$ROS_PYTHON_VERSION == 2">python-numpy</test_depend>
+  <test_depend condition="$ROS_PYTHON_VERSION == 3">python3-numpy</test_depend>
 
   <export>
     <message_generator>py</message_generator>

--- a/src/genpy/message.py
+++ b/src/genpy/message.py
@@ -43,6 +43,8 @@ import math
 import struct
 import sys
 
+import numpy as np
+
 import genmsg
 
 import yaml
@@ -262,7 +264,7 @@ def check_type(field_name, field_type, field_val):
             if field_val >= maxval:
                 raise SerializationError('field %s exceeds specified width [%s]' % (field_name, field_type))
         elif field_type in ['float32', 'float64']:
-            if type(field_val) not in [float, int, long]:
+            if type(field_val) not in [float, int, long, np.float32, np.float64, np.int8, np.int16, np.int32, np.int64, np.uint8, np.uint16, np.uint32, np.uint64]:
                 raise SerializationError('field %s must be float type' % field_name)
         elif field_type == 'bool':
             if field_val not in [True, False, 0, 1]:

--- a/src/genpy/message.py
+++ b/src/genpy/message.py
@@ -261,6 +261,9 @@ def check_type(field_name, field_type, field_val):
             maxval = int(math.pow(2, _widths[field_type]))
             if field_val >= maxval:
                 raise SerializationError('field %s exceeds specified width [%s]' % (field_name, field_type))
+        elif field_type in ['float32', 'float64']:
+            if type(field_val) not in [float, int, long]:
+                raise SerializationError('field %s must be float type' % field_name)
         elif field_type == 'bool':
             if field_val not in [True, False, 0, 1]:
                 raise SerializationError('field %s is not a bool' % (field_name))

--- a/src/genpy/message.py
+++ b/src/genpy/message.py
@@ -43,8 +43,6 @@ import math
 import struct
 import sys
 
-import numpy as np
-
 import genmsg
 
 import yaml
@@ -59,13 +57,19 @@ try:
 except NameError:  # Python 3
     from importlib import reload
 
-# common struct pattern singletons for msgs to use. Although this
-# would better placed in a generator-specific module, we don't want to
-# add another import to messages (which incurs higher import cost)
-
 if sys.version > '3':
     long = int
 
+try:
+    import numpy as np
+    _valid_float_types = [float, int, long, np.float32, np.float64, np.int8, np.int16, np.int32, np.int64, np.uint8,
+                          np.uint16, np.uint32, np.uint64]
+except ImportError:
+    _valid_float_types = [float, int, long]
+
+# common struct pattern singletons for msgs to use. Although this
+# would better placed in a generator-specific module, we don't want to
+# add another import to messages (which incurs higher import cost)
 struct_I = struct.Struct('<I')
 
 _warned_decoding_error = set()
@@ -264,7 +268,7 @@ def check_type(field_name, field_type, field_val):
             if field_val >= maxval:
                 raise SerializationError('field %s exceeds specified width [%s]' % (field_name, field_type))
         elif field_type in ['float32', 'float64']:
-            if type(field_val) not in [float, int, long, np.float32, np.float64, np.int8, np.int16, np.int32, np.int64, np.uint8, np.uint16, np.uint32, np.uint64]:
+            if type(field_val) not in _valid_float_types:
                 raise SerializationError('field %s must be float type' % field_name)
         elif field_type == 'bool':
             if field_val not in [True, False, 0, 1]:

--- a/test/test_genpy_message.py
+++ b/test/test_genpy_message.py
@@ -364,6 +364,7 @@ class MessageTest(unittest.TestCase):
 
         check_type will throw an exception when it fails
         """
+        import numpy as np
         genpy.message.check_type('test', 'uint8[]', 'byteDataIsAStringInPy')
         genpy.message.check_type('test', 'char[]', 'byteDataIsAStringInPy')
         genpy.message.check_type('test', 'uint8[]', [3, 4, 5])
@@ -387,12 +388,17 @@ class MessageTest(unittest.TestCase):
         genpy.message.check_type('test', 'duration', Duration(5))
         genpy.message.check_type('test', 'float32', 5)
         genpy.message.check_type('test', 'float32', 5.0)
+        genpy.message.check_type('test', 'float32', np.int16(5))
+        genpy.message.check_type('test', 'float32', np.float32(5.0))
         genpy.message.check_type('test', 'float32', float('inf'))
         genpy.message.check_type('test', 'float32', -float('inf'))
         genpy.message.check_type('test', 'float32', float('nan'))
         genpy.message.check_type('test', 'float32', -float('nan'))
         genpy.message.check_type('test', 'float32', 2147483647)   # resulting float: 2147483648.0
         genpy.message.check_type('test', 'float64', 5.0)
+        genpy.message.check_type('test', 'float64', 1 + np.finfo(np.float64).eps)
+        genpy.message.check_type('test', 'float64', np.float64(5.0))
+        genpy.message.check_type('test', 'float64', np.int32(2147483647))
         # smallest representable float larger than 1.0 in builtin float type (64 bits). conversion to float32 loses precision.
         genpy.message.check_type('test', 'float32', float(1 + 2**-52))
 

--- a/test/test_genpy_message.py
+++ b/test/test_genpy_message.py
@@ -385,6 +385,16 @@ class MessageTest(unittest.TestCase):
         genpy.message.check_type('test', 'string', 'IAmAString')
         genpy.message.check_type('test', 'time', Time())
         genpy.message.check_type('test', 'duration', Duration(5))
+        genpy.message.check_type('test', 'float32', 5)
+        genpy.message.check_type('test', 'float32', 5.0)
+        genpy.message.check_type('test', 'float32', float('inf'))
+        genpy.message.check_type('test', 'float32', -float('inf'))
+        genpy.message.check_type('test', 'float32', float('nan'))
+        genpy.message.check_type('test', 'float32', -float('nan'))
+        genpy.message.check_type('test', 'float32', 2147483647)   # resulting float: 2147483648.0
+        genpy.message.check_type('test', 'float64', 5.0)
+        # smallest representable float larger than 1.0 in builtin float type (64 bits). conversion to float32 loses precision.
+        genpy.message.check_type('test', 'float32', float(1 + 2**-52))
 
     def test_check_types_invalid(self):
         from genpy import SerializationError
@@ -404,6 +414,8 @@ class MessageTest(unittest.TestCase):
                           'test', 'bool', -2)
         self.assertRaises(SerializationError, genpy.message.check_type,
                           'test', 'bool', 2)
+        self.assertRaises(SerializationError, genpy.message.check_type,
+                          'test', 'float64', 'someString')
         try:
             u = unichr(1234)
         except NameError:
@@ -735,7 +747,7 @@ foo " bar
             m.serialize(buff)
             assert False, 'This should have raised a genpy.SerializationError'
         except genpy.SerializationError as e:
-            self.assertEqual(str(e), "<class 'struct.error'>: 'required argument is not a float' when writing '1.0'")
+            self.assertEqual(str(e), "field float must be float type")
         except Exception:
             assert False, 'This should have raised a genpy.SerializationError instead'
 


### PR DESCRIPTION
Fixes #130.

Specifically, this PR improves the error messages during serialization. Consider the following script:

```python
from io import BytesIO
from geometry_msgs.msg import PoseStamped

msg = PoseStamped()
msg.pose.position.x = '0.0'
buff = BytesIO()
msg.serialize(buff)
```

**Old behavior:**

```
Traceback (most recent call last):
  File "/opt/ros/noetic/lib/python3/dist-packages/geometry_msgs/msg/_PoseStamped.py", line 106, in serialize
    buff.write(_get_struct_7d().pack(_x.pose.position.x, _x.pose.position.y, _x.pose.position.z, _x.pose.orientation.x, _x.pose.orientation.y, _x.pose.orientation.z, _x.pose.orientation.w))
struct.error: required argument is not a float

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "src/genpy/test.py", line 9, in <module>
    msg.serialize(buff)
  File "/opt/ros/noetic/lib/python3/dist-packages/geometry_msgs/msg/_PoseStamped.py", line 107, in serialize
    except struct.error as se: self._check_types(struct.error("%s: '%s' when writing '%s'" % (type(se), str(se), str(locals().get('_x', self)))))
  File "/opt/ros/noetic/lib/python3/dist-packages/genpy/message.py", line 364, in _check_types
    raise SerializationError(str(exc))
genpy.message.SerializationError: <class 'struct.error'>: 'required argument is not a float' when writing 'header: 
  seq: 0
  stamp: 
    secs: 0
    nsecs:         0
  frame_id: ''
pose: 
  position: 
    x: "0.0"
    y: 0.0
    z: 0.0
  orientation: 
    x: 0.0
    y: 0.0
    z: 0.0
    w: 0.0'
```

**New behavior:**

```
Traceback (most recent call last):
  File "/opt/ros/noetic/lib/python3/dist-packages/geometry_msgs/msg/_PoseStamped.py", line 106, in serialize
    buff.write(_get_struct_7d().pack(_x.pose.position.x, _x.pose.position.y, _x.pose.position.z, _x.pose.orientation.x, _x.pose.orientation.y, _x.pose.orientation.z, _x.pose.orientation.w))
struct.error: required argument is not a float

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "src/genpy/test.py", line 9, in <module>
    msg.serialize(buff)
  File "/opt/ros/noetic/lib/python3/dist-packages/geometry_msgs/msg/_PoseStamped.py", line 107, in serialize
    except struct.error as se: self._check_types(struct.error("%s: '%s' when writing '%s'" % (type(se), str(se), str(locals().get('_x', self)))))
  File "/ws/src/genpy/src/genpy/message.py", line 392, in _check_types
    check_type(n, t, getattr(self, n))
  File "/ws/src/genpy/src/genpy/message.py", line 323, in check_type
    check_type('%s.%s' % (field_name, n), t, getattr(field_val, n))
  File "/ws/src/genpy/src/genpy/message.py", line 323, in check_type
    check_type('%s.%s' % (field_name, n), t, getattr(field_val, n))
  File "/ws/src/genpy/src/genpy/message.py", line 272, in check_type
    raise SerializationError('field %s must be float type' % field_name)
genpy.message.SerializationError: field pose.position.x must be float type
```