### PR TITLE
python3 guard for using rosmsg codec (take 2)

### DIFF
--- a/src/genpy/generator.py
+++ b/src/genpy/generator.py
@@ -758,7 +758,8 @@ def deserialize_fn_generator(msg_context, spec, is_numpy=False):  # noqa: D401
     :param is_numpy: if True, generate serializer code for numpy
       datatypes instead of Python lists, ``bool``
     """
-    yield 'codecs.lookup_error("rosmsg").msg_type = self._type'
+    yield 'if python3:'
+    yield INDENT+'codecs.lookup_error("rosmsg").msg_type = self._type'
     yield 'try:'
     package = spec.package
     # Instantiate embedded type classes

--- a/src/genpy/message.py
+++ b/src/genpy/message.py
@@ -68,23 +68,24 @@ struct_I = struct.Struct('<I')
 
 _warned_decoding_error = set()
 
-# Notify the user while not crashing in the face of errors attempting
-# to decode non-unicode data within a ROS message.
-class RosMsgUnicodeErrors:
-    def __init__(self):
-        self.msg_type = None
+if sys.hexversion >= 0x03000000:
+    # Notify the user while not crashing in the face of errors attempting
+    # to decode non-unicode data within a ROS message.
+    class RosMsgUnicodeErrors:
+        def __init__(self):
+            self.msg_type = None
 
-    def __call__(self, err):
-        global _warned_decoding_error
-        if self.msg_type not in _warned_decoding_error:
-            _warned_decoding_error.add(self.msg_type)
-            # Lazy import to avoid this cost in the non-error case.
-            import logging
-            logger = logging.getLogger('rosout')
-            extra = "message %s" % self.msg_type if self.msg_type else "unknown message"
-            logger.error("Characters replaced when decoding %s (will print only once): %s", extra, err)
-        return codecs.replace_errors(err)
-codecs.register_error('rosmsg', RosMsgUnicodeErrors())
+        def __call__(self, err):
+            global _warned_decoding_error
+            if self.msg_type not in _warned_decoding_error:
+                _warned_decoding_error.add(self.msg_type)
+                # Lazy import to avoid this cost in the non-error case.
+                import logging
+                logger = logging.getLogger('rosout')
+                extra = "message %s" % self.msg_type if self.msg_type else "unknown message"
+                logger.error("Characters replaced when decoding %s (will print only once): %s", extra, err)
+            return codecs.replace_errors(err)
+    codecs.register_error('rosmsg', RosMsgUnicodeErrors())
 
 
 def isstring(s):


### PR DESCRIPTION
Replaces #133 (since I didn't have permissions to push to the forked branch) and closes #132.

This patch makes the remaining code for the custom codec error handler conditional on the Python version.

@gwendolynbrook @mikepurvis FYI