### PR TITLE
GitHub Action to lint Python code

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -1,0 +1,25 @@
+name: lint_python
+on: [pull_request, push]
+jobs:
+  lint_python:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - run: pip install --upgrade pip wheel
+      - run: pip install bandit black codespell flake8 flake8-bugbear
+                         flake8-comprehensions isort mypy pytest pyupgrade safety
+      - run: bandit --recursive --skip B101 . || true  # B101 is assert statements
+      - run: black --check . || true
+      - run: codespell || true  # --ignore-words-list="" --skip="*.css,*.js,*.lock"
+      - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+      - run: flake8 . --count --exit-zero --max-complexity=10 --max-line-length=88
+                      --show-source --statistics
+      - run: isort --check-only --profile black . || true
+      - run: pip install -r requirements.txt || pip install --editable . || true
+      - run: mkdir --parents --verbose .mypy_cache
+      - run: mypy --ignore-missing-imports --install-types --non-interactive . || true
+      - run: pytest . || true
+      - run: pytest --doctest-modules . || true
+      - run: shopt -s globstar && pyupgrade --py36-plus **/*.py || true
+      - run: safety check

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -10,12 +10,12 @@ jobs:
       - run: pip install bandit codespell flake8 mypy pytest pyupgrade safety
       - run: bandit --recursive --skip B101,B108,B110,B307,B506 .
       - run: codespell --ignore-words-list="te" || true  # See PR #142
-      - run: flake8 --ignore=E111,E12,,E222,E226,E231,E241,E26,E30,E70,E722,E741,F401,F841
+      - run: flake8 --count --ignore=E231,E261,E265,E701,E722,F401
                     --max-complexity=34 --max-line-length=184
-                    --show-source --statistics --count
+                    --show-source --statistics
       - name: Run pip install --editable .
         run: |
-          pip install catkin_pkg pyros-genmsg
+          pip install catkin_pkg nose pyros-genmsg
           pip install --editable .
           mkdir --parents --verbose .mypy_cache
       - run: mypy --ignore-missing-imports --install-types --non-interactive . || true

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -15,8 +15,8 @@ jobs:
                     --show-source --statistics --count
       - name: Run pip install --editable .
         run: |
-          pip install catkin_pkg
-          pip install --editable . || true
+          pip install catkin_pkg pyros-genmsg
+          pip install --editable .
           mkdir --parents --verbose .mypy_cache
       - run: mypy --ignore-missing-imports --install-types --non-interactive . || true
       - run: pytest || pytest --doctest-modules || true

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -6,20 +6,19 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
-      - run: pip install --upgrade pip wheel
-      - run: pip install bandit black codespell flake8 flake8-bugbear
-                         flake8-comprehensions isort mypy pytest pyupgrade safety
-      - run: bandit --recursive --skip B101 . || true  # B101 is assert statements
-      - run: black --check . || true
-      - run: codespell || true  # --ignore-words-list="" --skip="*.css,*.js,*.lock"
-      - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-      - run: flake8 . --count --exit-zero --max-complexity=10 --max-line-length=88
-                      --show-source --statistics
-      - run: isort --check-only --profile black . || true
-      - run: pip install -r requirements.txt || pip install --editable . || true
-      - run: mkdir --parents --verbose .mypy_cache
+      - run: pip install --upgrade pip
+      - run: pip install bandit codespell flake8 mypy pytest pyupgrade safety
+      - run: bandit --recursive --skip B101,B108,B110,B307,B506 .
+      - run: codespell --ignore-words-list="te" || true  # See PR #142
+      - run: flake8 --ignore=E111,E12,,E222,E226,E231,E241,E26,E30,E70,E722,E741,F401,F841
+                    --max-complexity=34 --max-line-length=184
+                    --show-source --statistics --count
+      - name: Run pip install --editable .
+        run: |
+          pip install catkin_pkg
+          pip install --editable . || true
+          mkdir --parents --verbose .mypy_cache
       - run: mypy --ignore-missing-imports --install-types --non-interactive . || true
-      - run: pytest . || true
-      - run: pytest --doctest-modules . || true
+      - run: pytest || pytest --doctest-modules || true
       - run: shopt -s globstar && pyupgrade --py36-plus **/*.py || true
       - run: safety check

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -15,7 +15,7 @@ jobs:
                     --show-source --statistics
       - name: Run pip install --editable .
         run: |
-          pip install catkin_pkg nose pyros-genmsg
+          pip install catkin_pkg nose numpy pyros-genmsg
           pip install --editable .
           mkdir --parents --verbose .mypy_cache
       - run: mypy --ignore-missing-imports --install-types --non-interactive . || true

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -10,7 +10,7 @@ jobs:
       - run: pip install bandit codespell flake8 mypy pytest pyupgrade safety
       - run: bandit --recursive --skip B101,B108,B110,B307,B506 .
       - run: codespell --ignore-words-list="te" || true  # See PR #142
-      - run: flake8 --count --ignore=E231,E261,E265,E701,E722,F401
+      - run: flake8 --count --ignore=E12,E226,E231,E261,E265,E701,E722,F401
                     --max-complexity=34 --max-line-length=184
                     --show-source --statistics
       - name: Run pip install --editable .

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -11,7 +11,8 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys, os
+import os
+import sys
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/src/genpy/generator.py
+++ b/src/genpy/generator.py
@@ -127,8 +127,8 @@ class Special:
 
 
 _SPECIAL_TYPES = {
-    genmsg.HEADER:   Special('std_msgs.msg._Header.Header()',     None, 'import std_msgs.msg'),
-    genmsg.TIME:     Special('genpy.Time()',     '%s.canon()', 'import genpy'),
+    genmsg.HEADER: Special('std_msgs.msg._Header.Header()', None, 'import std_msgs.msg'),
+    genmsg.TIME: Special('genpy.Time()', '%s.canon()', 'import genpy'),
     genmsg.DURATION: Special('genpy.Duration()', '%s.canon()', 'import genpy'),
     }
 
@@ -340,7 +340,7 @@ def compute_import(msg_context, package, type_):
         iter_types = get_registered_ex(msg_context, full_msg_type).types
         for t in iter_types:
             assert t != full_msg_type, 'msg [%s] has circular self-dependencies' % (full_msg_type)
-            full_sub_type = '%s/%s' % (package, t)
+            # full_sub_type = '%s/%s' % (package, t)  # unused variable
             log('compute_import', full_msg_type, package, t)
             sub = compute_import(msg_context, package, t)
             retval.extend([x for x in sub if x not in retval])
@@ -971,8 +971,8 @@ def msg_generator(msg_context, spec, search_path):
 
 def srv_generator(msg_context, spec, search_path):
     for mspec in (spec.request, spec.response):
-        for l in msg_generator(msg_context, mspec, search_path):
-            yield l
+        for line in msg_generator(msg_context, mspec, search_path):
+            yield line
 
     name = spec.short_name
     req, resp = ['%s%s' % (name, suff) for suff in ['Request', 'Response']]
@@ -1037,8 +1037,8 @@ class Generator(object):
         spec = self.spec_loader_fn(msg_context, f, full_type)
         outfile = compute_outfile_name(outdir, os.path.basename(f), self.ext)
         with open(outfile, 'w') as f:
-            for l in self.generator_fn(msg_context, spec, search_path):
-                f.write(l+'\n')
+            for line in self.generator_fn(msg_context, spec, search_path):
+                f.write(line + '\n')
         return outfile
 
     def generate_messages(self, package, package_files, outdir, search_path):  # noqa: D200, D400, D401

--- a/src/genpy/message.py
+++ b/src/genpy/message.py
@@ -74,6 +74,7 @@ struct_I = struct.Struct('<I')
 
 _warned_decoding_error = set()
 
+
 # Notify the user while not crashing in the face of errors attempting
 # to decode non-unicode data within a ROS message.
 class RosMsgUnicodeErrors:
@@ -90,6 +91,8 @@ class RosMsgUnicodeErrors:
             extra = "message %s" % self.msg_type if self.msg_type else "unknown message"
             logger.error("Characters replaced when decoding %s (will print only once): %s", extra, err)
         return codecs.replace_errors(err)
+
+
 codecs.register_error('rosmsg', RosMsgUnicodeErrors())
 
 

--- a/test/test_genpy_message.py
+++ b/test/test_genpy_message.py
@@ -480,7 +480,8 @@ class MessageTest(unittest.TestCase):
             __slots__ = ['a', 'b']
             _slot_types = ['int32', 'int32']
 
-            def _get_types(self): return ['int32', 'int32']
+            def _get_types(self):
+                return ['int32', 'int32']
 
             def __init__(self, *args, **kwds):
                 super(M2, self).__init__(*args, **kwds)

--- a/test/test_genpy_rostime.py
+++ b/test/test_genpy_rostime.py
@@ -99,7 +99,8 @@ class RostimeTest(unittest.TestCase):
         self.assertNotEquals(v, TVal(0, 0))
         self.assertNotEquals(v.__hash__(), TVal(0, 0).__hash__())
         self.assertEquals(NotImplemented, v.__ge__(0))
-        class Foo(object): pass
+        class Foo(object):
+            pass
         self.assertEquals(NotImplemented, v.__gt__(Foo()))
         self.assertEquals(NotImplemented, v.__ge__(Foo()))
         self.assertEquals(NotImplemented, v.__le__(Foo()))
@@ -183,14 +184,16 @@ class RostimeTest(unittest.TestCase):
         # #1600 Duration > Time should fail
         failed = False
         try:
-          v = Duration.from_sec(0.1) > Time.from_sec(0.5)
-          failed = True
-        except: pass
+            v = Duration.from_sec(0.1) > Time.from_sec(0.5)
+            failed = True
+        except:
+            pass
         self.failIf(failed, "should have failed to compare")
         try:
-          v = Time.from_sec(0.4) > Duration.from_sec(0.1)
-          failed = True
-        except: pass
+            v = Time.from_sec(0.4) > Duration.from_sec(0.1)
+            failed = True
+        except:
+            pass
         self.failIf(failed, "should have failed to compare")
 
         # TODO: sub
@@ -199,12 +202,14 @@ class RostimeTest(unittest.TestCase):
         try:
             Time(-1)
             failed = True
-        except: pass
+        except:
+            pass
         self.failIf(failed, "negative time not allowed")
         try:
             Time(1, -1000000001)
             failed = True
-        except: pass
+        except:
+            pass
         self.failIf(failed, "negative time not allowed")
 
         # test Time.now() is within 10 seconds of actual time (really generous)
@@ -225,7 +230,8 @@ class RostimeTest(unittest.TestCase):
         try:
             v = Time(1,0) + Time(1, 0)
             failed = True
-        except: pass
+        except:
+            pass
         self.failIf(failed, "Time + Time must fail")
 
         # - time + duration
@@ -262,13 +268,16 @@ class RostimeTest(unittest.TestCase):
         try:
             v = Time(1,0) - 1
             failed = True
-        except: pass
+        except:
+            pass
         self.failIf(failed, "Time - non Duration must fail")
-        class Foob(object): pass
+        class Foob(object):
+            pass
         try:
             v = Time(1,0) - Foob()
             failed = True
-        except: pass
+        except:
+            pass
         self.failIf(failed, "Time - non TVal must fail")
 
         # - Time - Duration
@@ -304,7 +313,8 @@ class RostimeTest(unittest.TestCase):
         try:
             Time(0.5, 0.5)
             self.fail("should have thrown value error")
-        except ValueError: pass
+        except ValueError:
+            pass
 
     def test_Duration(self):
         from genpy.rostime import Time, Duration
@@ -336,7 +346,8 @@ class RostimeTest(unittest.TestCase):
         try:
             v = Duration(1,0) + 1
             failed = True
-        except: pass
+        except:
+            pass
         self.failIf(failed, "Duration + int must fail")
 
         v = Duration(1,0) + Duration(1, 0)
@@ -362,12 +373,14 @@ class RostimeTest(unittest.TestCase):
         try:
             v = Duration(1,0) - 1
             failed = True
-        except: pass
+        except:
+            pass
         self.failIf(failed, "Duration - non duration must fail")
         try:
             v = Duration(1, 0) - Time(1,0)
             failed = True
-        except: pass
+        except:
+            pass
         self.failIf(failed, "Duration - Time must fail")
 
         v = Duration(1,0) - Duration(1, 0)
@@ -401,7 +414,8 @@ class RostimeTest(unittest.TestCase):
         try:
             Duration(0.5, 0.5)
             self.fail("should have thrown value error")
-        except ValueError: pass
+        except ValueError:
+            pass
 
         # Test mul
         self.assertEquals(Duration(4), Duration(2) * 2)

--- a/test/test_genpy_rostime.py
+++ b/test/test_genpy_rostime.py
@@ -99,8 +99,10 @@ class RostimeTest(unittest.TestCase):
         self.assertNotEquals(v, TVal(0, 0))
         self.assertNotEquals(v.__hash__(), TVal(0, 0).__hash__())
         self.assertEquals(NotImplemented, v.__ge__(0))
+
         class Foo(object):
             pass
+
         self.assertEquals(NotImplemented, v.__gt__(Foo()))
         self.assertEquals(NotImplemented, v.__ge__(Foo()))
         self.assertEquals(NotImplemented, v.__le__(Foo()))
@@ -168,7 +170,6 @@ class RostimeTest(unittest.TestCase):
             self.assertEquals(0, v.nsecs)
             self.assertEquals(-1, v.to_sec())
             self.assertEquals(-1000000000, v.to_nsec())
-
 
         # test some more hashes
         self.assertEquals(TVal(1).__hash__(), TVal(1).__hash__())
@@ -261,7 +262,7 @@ class RostimeTest(unittest.TestCase):
 
         v = Time(100, 100) + Duration(300, -101)
         self.assertEquals(Time(399, 999999999), v)
-        v =  Duration(300, -101) + Time(100, 100)
+        v = Duration(300, -101) + Time(100, 100)
         self.assertEquals(Time(399, 999999999), v)
 
         # test subtraction
@@ -271,6 +272,7 @@ class RostimeTest(unittest.TestCase):
         except:
             pass
         self.failIf(failed, "Time - non Duration must fail")
+
         class Foob(object):
             pass
         try:
@@ -278,6 +280,7 @@ class RostimeTest(unittest.TestCase):
             failed = True
         except:
             pass
+
         self.failIf(failed, "Time - non TVal must fail")
 
         # - Time - Duration


### PR DESCRIPTION
Results: https://github.com/cclauss/genpy/actions

https://flake8.pycqa.org/en/latest/user/error-codes.html

On the flake8 test selection, this PR does  _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead, these tests focus on runtime safety and correctness:
* __E9__ tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python, they result in the script halting/crashing on the user.
* __F63__ tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).  Python >= 3.8 will raise SyntaxWarnings on these instances.
* __F7__ tests logic errors and syntax errors in type hints
* __F82__ tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python, a __NameError__ is raised which will halt/crash the script on the user.