### PR TITLE
[revised, tests added]  added support for buffer / memoryview data

### DIFF
--- a/src/genpy/generate_struct.py
+++ b/src/genpy/generate_struct.py
@@ -186,3 +186,17 @@ def unpack3(var, struct_var, buff):
     :param buff: buffer that the unpack reads from, ``StringIO``
     """
     return '%s = %s.unpack(%s)' % (var, struct_var, buff)
+
+
+def memoryview_len(view):
+    """
+    Compute the size (in bytes) of a ``memoryview`` object.
+
+    This is the same as memoryview.nbytes, but compatible with Python 2.
+
+    :param view: The ``memoryview`` object.
+    """
+    length = view.itemsize
+    for s in view.shape:
+        length *= s
+    return length

--- a/test/files/array/uint8_fixed_ser.txt
+++ b/test/files/array/uint8_fixed_ser.txt
@@ -1,5 +1,18 @@
-# - if encoded as a list instead, serialize as bytes instead of string
-if type(data) in [list, tuple]:
-  buff.write(_get_struct_8B().pack(*data))
+# check for buffer protocol support
+try:
+  # we want to process str and bytes by the except clause
+  if isinstance(data, bytes) or isinstance(data, str):
+    raise TypeError()
+  tmp = memoryview(data)
+except TypeError:
+  # - if encoded as a list instead, serialize as bytes instead of string
+  if type(data) in [list, tuple]:
+    buff.write(_get_struct_8B().pack(*data))
+  else:
+    buff.write(_get_struct_8s().pack(data))
 else:
-  buff.write(_get_struct_8s().pack(data))
+  from genpy.generate_struct import memoryview_len
+  tmp_len = memoryview_len(tmp)
+  if tmp_len != 8:
+    raise TypeError("expected 8 bytes, got %i" % (tmp_len,))
+  buff.write(tmp[:8])

--- a/test/files/array/uint8_fixed_ser_np.txt
+++ b/test/files/array/uint8_fixed_ser_np.txt
@@ -1,5 +1,18 @@
-# - if encoded as a list instead, serialize as bytes instead of string
-if type(data) in [list, tuple]:
-  buff.write(_get_struct_8B().pack(*data))
+# check for buffer protocol support
+try:
+  # we want to process str and bytes by the except clause
+  if isinstance(data, bytes) or isinstance(data, str):
+    raise TypeError()
+  tmp = memoryview(data)
+except TypeError:
+  # - if encoded as a list instead, serialize as bytes instead of string
+  if type(data) in [list, tuple]:
+    buff.write(_get_struct_8B().pack(*data))
+  else:
+    buff.write(_get_struct_8s().pack(data))
 else:
-  buff.write(_get_struct_8s().pack(data))
+  from genpy.generate_struct import memoryview_len
+  tmp_len = memoryview_len(tmp)
+  if tmp_len != 8:
+    raise TypeError("expected 8 bytes, got %i" % (tmp_len,))
+  buff.write(tmp[:8])

--- a/test/files/array/uint8_varlen_ser.txt
+++ b/test/files/array/uint8_varlen_ser.txt
@@ -1,6 +1,13 @@
 length = len(data)
-# - if encoded as a list instead, serialize as bytes instead of string
-if type(data) in [list, tuple]:
-  buff.write(struct.Struct('<I%sB'%length).pack(length, *data))
-else:
-  buff.write(struct.Struct('<I%ss'%length).pack(length, data))
+# check for buffer protocol support
+try:
+  tmp = memoryview(data)
+  from genpy.generate_struct import memoryview_len
+  buff.write(struct.Struct('<I').pack(memoryview_len(tmp)))
+  buff.write(tmp)
+except TypeError:
+  # - if encoded as a list instead, serialize as bytes instead of string
+  if type(data) in [list, tuple]:
+    buff.write(struct.Struct('<I%sB'%length).pack(length, *data))
+  else:
+    buff.write(struct.Struct('<I%ss'%length).pack(length, data))

--- a/test/files/array/uint8_varlen_ser_np.txt
+++ b/test/files/array/uint8_varlen_ser_np.txt
@@ -1,6 +1,13 @@
 length = len(data)
-# - if encoded as a list instead, serialize as bytes instead of string
-if type(data) in [list, tuple]:
-  buff.write(struct.Struct('<I%sB'%length).pack(length, *data))
-else:
-  buff.write(struct.Struct('<I%ss'%length).pack(length, data))
+# check for buffer protocol support
+try:
+  tmp = memoryview(data)
+  from genpy.generate_struct import memoryview_len
+  buff.write(struct.Struct('<I').pack(memoryview_len(tmp)))
+  buff.write(tmp)
+except TypeError:
+  # - if encoded as a list instead, serialize as bytes instead of string
+  if type(data) in [list, tuple]:
+    buff.write(struct.Struct('<I%sB'%length).pack(length, *data))
+  else:
+    buff.write(struct.Struct('<I%ss'%length).pack(length, data))

--- a/test/msg/TestBinary.msg
+++ b/test/msg/TestBinary.msg
@@ -1,0 +1,2 @@
+uint8[] data_var
+uint8[4] data_fixed


### PR DESCRIPTION
I iterated on #108 to add support for direct serialization of buffer protocol objects.

Closes #107.

I've added as much tests as I could imagine.

The generated code is a bit ugly because I found that if you pass a string to `uint8[]` field, its length is not checked. I wanted to explicitly make sure this behavior is kept for strings, but it did not occur good to me to keep it for the buffer protocol objects.

One of the use-cases I have for this feature is incrementally building a `PointCloud2`. If you represent the data field as `bytearray`, you get all the nice `std::vector<>`-like behavior (amortized `O(1)` append). And if this `bytearray` can be directly used in serialization, then the only copy you need to make is the serialization itself. Currently, I need to call `bytes(my_bytearray_data)`, which makes a copy, and then pass this copy to the serialization. So that's an unnecessary copy of a whole lot of data (in the case of pointclouds).

---

`Struct.pack` pads with zeros if a shorter string is given, or cuts the string it if is longer:

    In[8]: struct.Struct('<4s').pack(b"asd")
    Out[8]: 'asd\x00'