### PR TITLE
Updated deprecated numpy types

### DIFF
--- a/src/genpy/generate_numpy.py
+++ b/src/genpy/generate_numpy.py
@@ -38,20 +38,20 @@ from . generate_struct import serialize
 
 # maps ros msg types to numpy types
 NUMPY_DTYPE = {
-    'float32': 'numpy.float32',
-    'float64': 'numpy.float64',
-    'bool': 'numpy.bool',
-    'int8': 'numpy.int8',
-    'int16': 'numpy.int16',
-    'int32': 'numpy.int32',
-    'int64': 'numpy.int64',
-    'uint8': 'numpy.uint8',
-    'uint16': 'numpy.uint16',
-    'uint32': 'numpy.uint32',
-    'uint64': 'numpy.uint64',
+    'float32': 'numpy.single',
+    'float64': 'numpy.double',
+    'bool': 'numpy.bool_',
+    'int8': 'numpy.byte',
+    'int16': 'numpy.intc',
+    'int32': 'numpy.int_',
+    'int64': 'numpy.longlong',
+    'uint8': 'numpy.ubyte',
+    'uint16': 'numpy.uintc',
+    'uint32': 'numpy.uint',
+    'uint64': 'numpy.ulonglong',
     # deprecated type
-    'char': 'numpy.uint8',
-    'byte': 'numpy.int8',
+    'char': 'numpy.ubyte',
+    'byte': 'numpy.byte',
     }
 
 

--- a/src/genpy/message.py
+++ b/src/genpy/message.py
@@ -62,8 +62,8 @@ if sys.version > '3':
 
 try:
     import numpy as np
-    _valid_float_types = [float, int, long, np.float32, np.float64, np.int8, np.int16, np.int32, np.int64, np.uint8,
-                          np.uint16, np.uint32, np.uint64]
+    _valid_float_types = [float, int, long, np.single, np.double, np.byte, np.intc, np.int_, np.longlong, np.ubyte,
+                          np.uintc, np.uint, np.ulonglong]
 except ImportError:
     _valid_float_types = [float, int, long]
 

--- a/test/files/array/int16_fixed_deser_np.txt
+++ b/test/files/array/int16_fixed_deser_np.txt
@@ -1,3 +1,3 @@
 start = end
 end += 20
-data = numpy.frombuffer(str[start:end], dtype=numpy.int16, count=10)
+data = numpy.frombuffer(str[start:end], dtype=numpy.intc, count=10)

--- a/test/files/array/int16_varlen_deser_np.txt
+++ b/test/files/array/int16_varlen_deser_np.txt
@@ -5,4 +5,4 @@ pattern = '<%sh'%length
 start = end
 s = struct.Struct(pattern)
 end += s.size
-data = numpy.frombuffer(str[start:end], dtype=numpy.int16, count=length)
+data = numpy.frombuffer(str[start:end], dtype=numpy.intc, count=length)

--- a/test/test_genpy_message.py
+++ b/test/test_genpy_message.py
@@ -388,17 +388,17 @@ class MessageTest(unittest.TestCase):
         genpy.message.check_type('test', 'duration', Duration(5))
         genpy.message.check_type('test', 'float32', 5)
         genpy.message.check_type('test', 'float32', 5.0)
-        genpy.message.check_type('test', 'float32', np.int16(5))
-        genpy.message.check_type('test', 'float32', np.float32(5.0))
+        genpy.message.check_type('test', 'float32', np.intc(5))
+        genpy.message.check_type('test', 'float32', np.single(5.0))
         genpy.message.check_type('test', 'float32', float('inf'))
         genpy.message.check_type('test', 'float32', -float('inf'))
         genpy.message.check_type('test', 'float32', float('nan'))
         genpy.message.check_type('test', 'float32', -float('nan'))
         genpy.message.check_type('test', 'float32', 2147483647)   # resulting float: 2147483648.0
         genpy.message.check_type('test', 'float64', 5.0)
-        genpy.message.check_type('test', 'float64', 1 + np.finfo(np.float64).eps)
-        genpy.message.check_type('test', 'float64', np.float64(5.0))
-        genpy.message.check_type('test', 'float64', np.int32(2147483647))
+        genpy.message.check_type('test', 'float64', 1 + np.finfo(np.double).eps)
+        genpy.message.check_type('test', 'float64', np.double(5.0))
+        genpy.message.check_type('test', 'float64', np.int_(2147483647))
         # smallest representable float larger than 1.0 in builtin float type (64 bits). conversion to float32 loses precision.
         genpy.message.check_type('test', 'float32', float(1 + 2**-52))
 


### PR DESCRIPTION
Since version 1.20 numpy deprecated types like `np.float32` with a warning. Since version 1.24 this creates an error which lets our ros CI fail. Pinning the numpy version only is a temporary solution. This PR solves the issue.

Used the [np types in 1.24](https://numpy.org/doc/stable/user/basics.types.html#basics-types) and [np types in 1.16](https://numpy.org/doc/1.16/user/basics.types.html) to get things correct.

