### PR TITLE
Fix bug in reduce_pattern

### DIFF
--- a/src/genpy/generate_struct.py
+++ b/src/genpy/generate_struct.py
@@ -77,7 +77,7 @@ def reduce_pattern(pattern):
     prev = pattern[0]
     count = 1
     new_pattern = ''
-    nums = [str(i) for i in range(0, 9)]
+    nums = [str(i) for i in range(10)]
     for c in pattern[1:]:
         if c == prev and c not in nums:
             count += 1


### PR DESCRIPTION
The function reduce_pattern only checks whether the current character in the format string is a number up to including 8. This causes a bug when reading ros messages containing an array which has a size that contains two consecutive 9s. This commit fixes this.